### PR TITLE
Add support for lexical parameters in SQL*Plus scripts, allow excluding lines which the parser does not understand.

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -343,15 +343,6 @@ ASTSqlPlusCommand SqlPlusCommand() :
   { jjtThis.setImage(sb.toString()) ; return jjtThis ; }
 }
 
-/*
-SRT 2011-04-17 This syntax breaks the parser when fields of record.attach* are referenced  in PL/SQL
-void attachLibrary() :
-{}
-{
-	<".attach"> <IDENTIFIER> <IDENTIFIER> <END> <IDENTIFIER>
-}
-*/
-
 /**
  * All global definitions of triggers, functions and procedures are evaluated here.
  * Every occurrence goes under a new PACKAGE-Node in the XML document.
@@ -5122,22 +5113,17 @@ TOKEN :
 	//( <LETTER> ( "#" ) )
   |
   (
-    "&"
-    (
-      ( <LETTER> | "_" ) ( <LETTER> | <DIGIT> | "$" | "_" | "#" )+
-      (".")?  
-    )?
+    <LEXICAL_PARAMETER> ( <LETTER> | <DIGIT> | "$" | "_" | "#" )*
   )
 	|
 	( (<LETTER> | "$" ) ( <LETTER> | <DIGIT> | "$" | "_" | "#" )* )
 	|
-//SRT	( "\"" (<_CHARACTER_WO_ASTERISK>)* "\"" )
 	( "\""  <LETTER> ( <LETTER> | <DIGIT> | "$" | "_" | "#" )* "\"" )
 >
 |
 < LEXICAL_PARAMETER:
   (
-    "&"
+    ("&&" | "&")
     (
       ( <LETTER> | <DIGIT> | "$" | "_" | "#" )+
       (".")?  

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -307,27 +307,53 @@ ASTSqlPlusCommand SqlPlusCommand() :
   (
   // e.g. SHOW ERRORS, GRANT EXECUTE ON ... TO ...
   // SQLPLUS commands
-  ( "@"
-  | <ACCEPT>
+  ( "@@"
+  | "@"
+  | <ACCEPT> | "ACC"
+  | "ARCHIVE LOG LIST"
+  | <ATTRIBUTE>
+  | "BREAK"
+  | "BTITLE"
+  | LOOKAHEAD({isKeyword("CLEAR")}) KEYWORD("CLEAR")
   | <COLUMN>
-  | <CONNECT>
+  | LOOKAHEAD({isKeyword("COL")}) KEYWORD("COL")
+  | LOOKAHEAD({isKeyword("COMPUTE")}) KEYWORD("COMPUTE")
+  | LOOKAHEAD({isKeyword("COMP")}) KEYWORD("COMP")
+  | <CONNECT> | "CONN"
   | <COPY>
-  | <DEFINE>
-  | <DISCONNECT>
-  | <EXECUTE>
+  | <DEFINE> | "DEF"
+  | "DESCRIBE" | "DESCR" | LOOKAHEAD({isKeyword("DESC")}) KEYWORD("DESC")
+  | <DISCONNECT> | "DISC"
+  | <EXECUTE> | "EXEC"
   | <EXIT>
-  | <HOST>
+  | <HOST> ( <_CHARACTER> | <SPECIAL_CHARACTERS> | <DELIMITER> ) *
+  | "$"    ( <_CHARACTER> | <SPECIAL_CHARACTERS> | <DELIMITER> ) *
+  | "!"    ( <_CHARACTER> | <SPECIAL_CHARACTERS> | <DELIMITER> ) *
+  // These characters are platform-specific, anyway...
+  | "INPUT"
+  | LOOKAHEAD({isKeyword("PASSWORD")}) KEYWORD("PASSWORD")
+  | LOOKAHEAD({isKeyword("PASSW")}) KEYWORD("PASSW")
+  | "PAUSE"
   | <PRINT>
-  | <PROMPT>
+  | <PROMPT> ( <_CHARACTER> | <SPECIAL_CHARACTERS> | <DELIMITER> ) *
   | <QUIT>
-  | <REMARK>
+  | LOOKAHEAD({isKeyword("RECOVER")}) KEYWORD("RECOVER")
+  | <REMARK> ( <_CHARACTER> | <SPECIAL_CHARACTERS> | <DELIMITER> ) *
+  | "REM" ( <_CHARACTER> | <SPECIAL_CHARACTERS> | <DELIMITER> ) *
   | <SET>
-  | <SHOW>
+  | <SHOW> | "SHO"
+  | <SHUTDOWN>
   | <SPOOL>
   | <START>
+  | <STARTUP>
+  | LOOKAHEAD({isKeyword("STORE")}) KEYWORD("STORE")
+  | "TIMING"
+  | "TTITLE"
   | <UNDEFINE>
-  | <VARIABLE>
+  | <VARIABLE> | "VAR"
   | <WHENEVER>
+  // XQUERY is not yet supported, because it is not a single-line command
+  // It should be handled as unknown, skipping to the next stand-alone "/".
   // DDL that might be encountered
   | LOOKAHEAD({isKeyword("COMMENT")}) KEYWORD("COMMENT")
   | <GRANT>
@@ -5078,23 +5104,6 @@ TOKEN [IGNORE_CASE]:
  */
 TOKEN :
 {
-< #GERMAN_SPECIAL_CHARACTERS: "Ä" | "Ö" | "Ü" | "ä" | "ü" | "ö" | "ß" >
-|
-< #LETTER: ["A"-"Z"] | ["a"-"z"] | <GERMAN_SPECIAL_CHARACTERS> >
-|
-< #DIGIT: ["0"-"9"]>
-|
-< #_CHARACTER: <_CHARACTER_WO_ASTERISK> | "'" >
-|
-< #_CHARACTER_WO_ASTERISK: <LETTER> | <DIGIT> | "(" | ")" | "+" | "-" | "*" | "/" | "<" | ">"
- | "=" | "!" | "~" | "^" | ";" | ":" | "." | "@" | "%" | "," | "\"" | "#"
- | "$" | "_" | "|" | "{" | "}" | "?" | "[" | "]"
- | " " | "\t" >
-|
-< #SPECIAL_CHARACTERS: "á" | "Ž" | "™" | "š" | "„" | "”" | "ý" | "²" | "€" | "³" | "µ">
-|
-< #DELIMITER: "+" | "%" | "'" | "\"" | "." | "/" | "(" | ")" | ":" | "," | "*" | "=" | "<" | ">" | "@" | ";" | "-">
-|
 <ESCAPED_AMPERSAND:
   "\\&"
 >
@@ -5153,6 +5162,23 @@ TOKEN :
 < JAVA_INTERFACE_CLASS: ( "SQLData" | "CustomDatum" | "OraData" ) >
 //|
 //< #BOOLEAN_LITERAL: "TRUE" | "FALSE" >
+|
+< #GERMAN_SPECIAL_CHARACTERS: "Ä" | "Ö" | "Ü" | "ä" | "ü" | "ö" | "ß" >
+|
+< #LETTER: ["A"-"Z"] | ["a"-"z"] | <GERMAN_SPECIAL_CHARACTERS> >
+|
+< #DIGIT: ["0"-"9"]>
+|
+< _CHARACTER: <_CHARACTER_WO_ASTERISK> | "'" >
+|
+< #_CHARACTER_WO_ASTERISK: <LETTER> | <DIGIT> | "(" | ")" | "+" | "-" | "*" | "/" | "<" | ">"
+ | "=" | "!" | "~" | "^" | ";" | ":" | "." | "@" | "%" | "," | "\"" | "#"
+ | "$" | "_" | "|" | "{" | "}" | "?" | "[" | "]"
+ | " " | "\t" >
+|
+< SPECIAL_CHARACTERS: "á" | "Ž" | "™" | "š" | "„" | "”" | "ý" | "²" | "€" | "³" | "µ">
+|
+< DELIMITER: "+" | "%" | "'" | "\"" | "." | "/" | "(" | ")" | ":" | "," | "*" | "=" | "<" | ">" | "@" | ";" | "-">
 }
 
 /**
@@ -6863,4 +6889,3 @@ ASTJavaInterfaceClass JavaInterfaceClass(): {}
         )
 	{ jjtThis.setImage(token.getImage()) ; jjtThis.value = token ; return jjtThis ; }
 }
-

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -3416,7 +3416,7 @@ ASTPrimaryPrefix PrimaryPrefix() :
 | LOOKAHEAD(Literal()) ( simpleNode = Literal() ) { sb.append(simpleNode.getImage()) ; }
 | LOOKAHEAD(SimpleExpression()) ( simpleNode = SimpleExpression() ) { sb.append(simpleNode.getImage()); }
 | ( simpleNode =Name() ) { sb.append(simpleNode.getImage()) ; }
-| SelectStatement()
+// | SelectStatement()
 | LOOKAHEAD("(" <SELECT>) "(" SelectStatement() ")"
 | LOOKAHEAD(<WITH>) (<WITH>) {sb.append("WITH ..."); }  Skip2NextTerminator(null,";")
 | LOOKAHEAD(("(")+ <WITH>) ("(") {sb.append("(WITH ..."); }  Skip2NextTerminator("(",")") ")"
@@ -4593,6 +4593,51 @@ SKIP :
 	" " | "\t" | "\f"
 }
 
+/* 
+This Grammar (or JavaCC) has several bugs.
+
+Currently (2021-02-26) it fails for things like
+- dbms_lob.trim(...),
+- scalar subqueries in the WHERE-clause,
+- TREAT(object AS type),
+just to name a few.
+
+Running PMD over a code base of approx. 1100 DDL scripts
+from a commercial product, the parser failed for 182 files.
+About 10% of these parsing errors actually showed flaws in the code,
+e.g. "\u2013" instead of "-", or utf-8 encoding instead of windows-1252
+(which is the standard for the product's scripts).
+Still, ~ 15% of perfectly valid DDL scripts could not be parsed by PMD.
+
+Nevertheless it should be best practice to call PMD for _every_ DDL script.
+
+Thus, we introduce the following workaround to cope with the situation.
+We introduce two special comments PMD-EXCLUDE-BEGIN and PMD-EXCLUDE-END
+which cause PMD to treat the source inbetween these comments more or less
+like a multi-line comment, or in other words, just not try to parse them.
+
+It is good practice to include a reason for excluding inside the
+-- PMD-EXCUDE-BEGIN comment.
+
+The PMD-EXCLUDE-BEGIN and PMD-EXLUDE-END comment lines must not contain
+other statements, e.g. do_xy(); -- PMD-EXCLUDE-BEGIN is invalid.
+
+Example:
+
+begin
+  do_something();
+  -- PMD-EXCLUDE-BEGIN: PMD does not like dbms_lob.trim (clash with TrimExpression)
+  dbms_lob.trim(the_blob, 1000);
+  -- PMD-EXCLUDE-END
+  do_something_else();
+end;
+
+A future version of PMD might pass the existence of the exclusion to the AST
+as an "ASTParsingExclusion" statement, perhaps including the comment and the
+excluded source, to allow for detecting this workaround with a rule.
+But for now, it is just skipped.
+*/
+
 /* COMMENTS */
 
 MORE :
@@ -4600,6 +4645,14 @@ MORE :
 	<"/**" ~["/"]> : IN_FORMAL_COMMENT
 |
 	"/*" : IN_MULTI_LINE_COMMENT
+| 
+  <"--" (" ")* "PMD-EXCLUDE-BEGIN" (" ")* (":")? (" ")* (~["\n", "\r"])*> : IN_PARSING_EXCLUSION
+}
+
+<IN_PARSING_EXCLUSION>
+SPECIAL_TOKEN :
+{
+  	<PARSING_EXCLUSION: "--" (" ")* "PMD-EXCLUDE-END" (~["\n", "\r"])* > : DEFAULT
 }
 
 SPECIAL_TOKEN :
@@ -4635,7 +4688,7 @@ SKIP :
 */
 
 <IN_FORMAL_COMMENT, IN_MULTI_LINE_COMMENT,
- IN_SQL_STATEMENT_ENDED_SEMICOLON>
+ IN_SQL_STATEMENT_ENDED_SEMICOLON, IN_PARSING_EXCLUSION>
 MORE :
 {
 	< ~[] >

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -301,7 +301,7 @@ ASTDDLCommand DDLCommand() :
 
 ASTSqlPlusCommand SqlPlusCommand() :
 {
- StringBuilder sb = new StringBuilder() ;
+  StringBuffer sb = new StringBuffer();
 }
 {
   (
@@ -337,11 +337,10 @@ ASTSqlPlusCommand SqlPlusCommand() :
   // Attach Library
   | "." <ATTACH>
   )
-  { sb.append(token.getImage()) ; sb.append(" ...") ; }
-  Skip2NextTokenOccurrence(EOL) //Tracker Issue 1433480 skip until next EOL Special Token
-  //[";" | "-"]
+  { sb.append(token.getImage()) ; sb.append(" ") ; sb.append(Read2NextTokenOccurrence(EOL).getImage()) ;
+  }
   )
-  { jjtThis.setImage(sb.toString()) ;  return jjtThis ; }
+  { jjtThis.setImage(sb.toString()) ; return jjtThis ; }
 }
 
 /*
@@ -1128,6 +1127,28 @@ ASTRead2NextOccurrence Read2NextOccurrence(String target) :
   Token nextToken = getToken(1);
   while (!nextToken.getImage().equals(target)
 	 && nextToken.kind!=EOF
+        )
+  {
+    nextToken = getNextToken();
+    sb.append(nextToken.getImage());
+    sb.append(' ');
+    nextToken = getToken(1);
+  }
+}
+{
+	{ jjtThis.setImage(sb.toString()) ;  jjtThis.value = sb.toString(); return jjtThis ;}
+}
+
+/*
+ Read Tokens up to but not including the target token.
+*/
+ASTRead2NextTokenOccurrence Read2NextTokenOccurrence(int target) :
+{
+  StringBuilder sb = new StringBuilder();
+  Token nextToken = getToken(1);
+  while (nextToken.kind!=target
+        && (null == nextToken.specialToken || nextToken.specialToken.kind!=target ) //In case the target is a Special Token
+        && nextToken.kind!=EOF
         )
   {
     nextToken = getNextToken();
@@ -5077,12 +5098,20 @@ TOKEN :
 |
 < #_CHARACTER_WO_ASTERISK: <LETTER> | <DIGIT> | "(" | ")" | "+" | "-" | "*" | "/" | "<" | ">"
  | "=" | "!" | "~" | "^" | ";" | ":" | "." | "@" | "%" | "," | "\"" | "#"
- | "$" | "&" | "_" | "|" | "{" | "}" | "?" | "[" | "]"
+ | "$" | "_" | "|" | "{" | "}" | "?" | "[" | "]"
  | " " | "\t" >
 |
 < #SPECIAL_CHARACTERS: "á" | "Ž" | "™" | "š" | "„" | "”" | "ý" | "²" | "€" | "³" | "µ">
 |
 < #DELIMITER: "+" | "%" | "'" | "\"" | "." | "/" | "(" | ")" | ":" | "," | "*" | "=" | "<" | ">" | "@" | ";" | "-">
+|
+<ESCAPED_AMPERSAND:
+  "\\&"
+>
+|
+<BACKSLASH:
+  "\\"
+>
 |
 < IDENTIFIER:
 	( ("$" | ":" | <LETTER>) ( <LETTER> | <DIGIT> | "$" | "_" | "#" )* ) // 2006-05-17 - Matthias Hendler - Bind variablen werden nun als Identifier akzeptiert.
@@ -5091,11 +5120,29 @@ TOKEN :
 	//( <LETTER> ( "$" ) )
 	//( <LETTER> ( "_" ) )
 	//( <LETTER> ( "#" ) )
+  |
+  (
+    "&"
+    (
+      ( <LETTER> | "_" ) ( <LETTER> | <DIGIT> | "$" | "_" | "#" )+
+      (".")?  
+    )?
+  )
 	|
 	( (<LETTER> | "$" ) ( <LETTER> | <DIGIT> | "$" | "_" | "#" )* )
 	|
 //SRT	( "\"" (<_CHARACTER_WO_ASTERISK>)* "\"" )
 	( "\""  <LETTER> ( <LETTER> | <DIGIT> | "$" | "_" | "#" )* "\"" )
+>
+|
+< LEXICAL_PARAMETER:
+  (
+    "&"
+    (
+      ( <LETTER> | <DIGIT> | "$" | "_" | "#" )+
+      (".")?  
+    )?
+  )
 >
 |
 < UNSIGNED_NUMERIC_LITERAL: <FLOAT_LITERAL> ( ["e","E"] (["-","+"])? <FLOAT_LITERAL> )? (["f","F","d","D"])? >

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -333,7 +333,6 @@ ASTSqlPlusCommand SqlPlusCommand() :
   | <GRANT>
   | <REVOKE>
   | <DROP>
-  | <IDENTIFIER>
   // Attach Library
   | "." <ATTACH>
   )

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -301,7 +301,7 @@ ASTDDLCommand DDLCommand() :
 
 ASTSqlPlusCommand SqlPlusCommand() :
 {
-  StringBuffer sb = new StringBuffer();
+  StringBuilder sb = new StringBuilder();
 }
 {
   (

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
@@ -167,7 +167,7 @@ public class PLSQLParserVisitorAdapter implements PLSQLParserVisitor {
     }
     
     @Override
-    public Object visit(ASTRead2NextTokenOccurrence  node, Object data) {
+    public Object visit(ASTRead2NextTokenOccurrence node, Object data) {
         return visit((PLSQLNode) node, data);
     }
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
@@ -165,6 +165,11 @@ public class PLSQLParserVisitorAdapter implements PLSQLParserVisitor {
     public Object visit(ASTRead2NextOccurrence node, Object data) {
         return visit((PLSQLNode) node, data);
     }
+    
+    @Override
+    public Object visit(ASTRead2NextTokenOccurrence  node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
 
     @Override
     public Object visit(ASTReadPastNextOccurrence node, Object data) {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -161,6 +161,7 @@ import net.sourceforge.pmd.lang.plsql.ast.ASTQueryBlock;
 import net.sourceforge.pmd.lang.plsql.ast.ASTQueryPartitionClause;
 import net.sourceforge.pmd.lang.plsql.ast.ASTRaiseStatement;
 import net.sourceforge.pmd.lang.plsql.ast.ASTRead2NextOccurrence;
+import net.sourceforge.pmd.lang.plsql.ast.ASTRead2NextTokenOccurrence;
 import net.sourceforge.pmd.lang.plsql.ast.ASTReadPastNextOccurrence;
 import net.sourceforge.pmd.lang.plsql.ast.ASTReferencesClause;
 import net.sourceforge.pmd.lang.plsql.ast.ASTRegexpLikeCondition;
@@ -482,6 +483,11 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
         return visit((PLSQLNode) node, data);
     }
 
+    @Override
+    public Object visit(ASTRead2NextTokenOccurrence node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+    
     @Override
     public Object visit(ASTReadPastNextOccurrence node, Object data) {
         return visit((PLSQLNode) node, data);

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoStatementTest.java
@@ -6,8 +6,8 @@ package net.sourceforge.pmd.lang.plsql.ast;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
 import net.sourceforge.pmd.lang.ast.ParseException;
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
 
 
 public class SelectIntoStatementTest extends AbstractPLSQLParserTst {

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoStatementTest.java
@@ -7,6 +7,8 @@ package net.sourceforge.pmd.lang.plsql.ast;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+import net.sourceforge.pmd.lang.ast.ParseException;
+
 
 public class SelectIntoStatementTest extends AbstractPLSQLParserTst {
 
@@ -17,7 +19,12 @@ public class SelectIntoStatementTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testParsingExample1() {
-        plsql.parseResource("SelectIntoStatementExample1.pls");
+        try {
+            plsql.parseResource("SelectIntoStatementExample1.pls");
+            throw new AssertionError("The last line of this example must cause a ParseException.");
+        } catch (ParseException e) {
+            // This is expected, because the last line of the example is valid only inside BEGIN END.
+        }
     }
 
     @Test

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/IsOfType.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/IsOfType.pls
@@ -17,7 +17,7 @@ IF ioFPOobj IS NOT OF TYPE (ONLY FPOGE_OBJ) THEN
 loFPOGE_OBJ:=treat(ioFPOobj AS FPOGE_OBJ);
 end if;
 
-loFPOGE_OBJ:=SELECT A FROM persons p WHERE VALUE(p) IS OF TYPE (employee_t);
-loFPOGE_OBJ:=SELECT A FROM persons p WHERE VALUE(p) IS NOT OF TYPE (ONLY employee_t, other_t);
+SELECT A into lo_FPOGE_OBJ FROM persons p WHERE VALUE(p) IS OF TYPE (employee_t);
+SELECT A into lo_FPOGE_OBJ FROM persons p WHERE VALUE(p) IS NOT OF TYPE (ONLY employee_t, other_t);
 
 end;


### PR DESCRIPTION
## Describe the PR

### Support lexical parameters

A lot of the source codes analyzed by PMD language/pl-sql are actually _SQL*Plus_ scripts.
That is, a mixture of SQL, DML and DDL commands and _SQL*Plus_ commands.
Among the _SQL*Plus_ features, the support for "lexical parameters" is problematic in particular (regarding parsing).
Those lexical parameters are very similar to environment variables in shell scripts or to _#define_ in C/C++.
The lexical parameters can be set/deleted with _DEFINE/UNDEFINE_ and _COLUMN ... NEW_VALUE ..._ and as arguments when calling scripts.
They can be referenced with _&_ or _&&_. A backslash character \ can be used to treat an _&_ literally. 
The interpretation of the ampersand and the backslash depends on the _SQL*Plus_ settings _DEFINE_ and _ESCAPE_.

These two characters are not part of SQL or PL/SQL, but only have a meaning in SQL*Plus.
Previously, the PMD PL/SQL parser failed when it found one of these characters (depending on where exactly the occur).

With this PR, the parser accepts source code including these characters, at least for typical use cases (tested this with a a code base of >1000 scripts of a commercial product).

### Exlduding lines from the parser.

A second problem is that the parser is far from perfect - in aforementioned code base approx 10% of the files could not be parsed, though they are perfectly valid.
One example where the parser fails is a scalar subquery in the WHERE-clause, another example is calling DBMS_LOB.TRIM.
Because it seems impossible (at least for me) to actually _fix_ the parser (the grammar is really complicated), this PR allows simply _excluding_ those lines where the parser fails.

Excluding lines from the parser can be achieved like this:

    begin
      do_something();
      -- pmd-exclude-begin: PMD does not like dbms_lob.trim (clash with TrimExpression)
      dbms_lob.trim(the_blob, 1000);
      -- pmd-exclude-end
      do_something_else(x);
    end;
    /

Note that this completely different from -- NOPMD comments, which require the parser to succeed!

## Related issues

Several issues where users report that the parser fails for their scripts.
Probably a lot of potential users try out PMD for their scripts and find that the parser doesn't work for their scripts, so they turn away from PMD.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ x ] Passing all unit tests
- [ x ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ x ] Added (in-code) documentation (if needed)

